### PR TITLE
fix for purge option; disabling purge by defaut

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -13,12 +13,12 @@ class sysctl::base (
   }
 
   file { '/etc/sysctl.d':
-    ensure => directory,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0755',
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
     # Magic hidden here
-    purge  => $purge,
+    purge   => $purge,
     recurse => $recurse,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,6 @@ define sysctl (
   $ensure  = undef,
 ) {
 
-  # Parent purged (by default) directory
   include sysctl::base
 
   # If we have a prefix, then add the dash to it


### PR DESCRIPTION
Hi,

The purge option to wipe out anything under /etc/sysctl.d which is not managed by sysctl - this option only works when 'recurse = true' is set. Thus, this patch adds the recurse option setting depending on what purge is set to.

This patch changes the default of purge to be 'false' since I feel it's safer to have false as the default and also since adding recurse will now make the purge work - we want to ensure that users of this module don't accidentally begin to see sysctl configuration settings wiped from their system if they were to upgrade their respective copies of this 'puppet-sysctl' module.

Tehmasp Chaudhri @tehmaspc
