### PR TITLE
The if for $ensure is unnecessary

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,23 +43,19 @@ define sysctl (
     ],
   }
 
-  if $ensure != 'absent' {
+  # The immediate change + re-check on each run "just in case"
+  exec { "sysctl-${title}":
+    command     => "/sbin/sysctl -p /etc/sysctl.d/${sysctl_d_file}",
+    refreshonly => true,
+    require     => File["/etc/sysctl.d/${sysctl_d_file}"],
+  }
 
-    # The immediate change + re-check on each run "just in case"
-    exec { "sysctl-${title}":
-      command     => "/sbin/sysctl -p /etc/sysctl.d/${sysctl_d_file}",
-      refreshonly => true,
-      require     => File["/etc/sysctl.d/${sysctl_d_file}"],
-    }
-
-    # For the few original values from the main file
-    exec { "update-sysctl.conf-${title}":
-      command     => "sed -i -e 's/^${title} *=.*/${title} = ${value}/' /etc/sysctl.conf",
-      path        => [ '/usr/sbin', '/sbin', '/usr/bin', '/bin' ],
-      refreshonly => true,
-      onlyif      => "grep -E '^${title} *=' /etc/sysctl.conf",
-    }
-
+  # For the few original values from the main file
+  exec { "update-sysctl.conf-${title}":
+    command     => "sed -i -e 's/^${title} *=.*/${title} = ${value}/' /etc/sysctl.conf",
+    path        => [ '/usr/sbin', '/sbin', '/usr/bin', '/bin' ],
+    refreshonly => true,
+    onlyif      => "grep -E '^${title} *=' /etc/sysctl.conf",
   }
 
 }


### PR DESCRIPTION
The if is unnecessary and the module fails when used with `$ensure == 'absent'`. Fix this problem.

Moreover, as execs have refreshonly enabled, the if is unnecessary
