### PR TITLE
Use a different separator for sed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,7 @@ define sysctl (
 
     # For the few original values from the main file
     exec { "update-sysctl.conf-${title}":
-      command     => "sed -i -e 's/^${title} *=.*/${title} = ${value}/' /etc/sysctl.conf",
+      command     => "sed -i -e 's#^${title} *=.*#${title} = ${value}#' /etc/sysctl.conf",
       path        => [ '/usr/sbin', '/sbin', '/usr/bin', '/bin' ],
       refreshonly => true,
       onlyif      => "grep -E '^${title} *=' /etc/sysctl.conf",


### PR DESCRIPTION
I have the following in /etc/sysctl.conf:
kernel.core_pattern = /var/dump/core.%e.%p

This can't be replaced, since the forward slash
is used by sed as separator. Use a different one.
