### PR TITLE
Silence a warning when strict_variables is enabled

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,7 @@ define sysctl (
     $file_source = $source
   } else {
     $file_content = template("${module_name}/sysctl.d-file.erb")
+    $file_source = undef
   }
 
   if $ensure != 'absent' {


### PR DESCRIPTION
I just turned on strict_variables and your module complained that $file_source was not defined:
```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Undefined variable "file_source" at /etc/puppet/environments/puppet_master/modules/sysctl/manifests/init.pp:55 on node ...
```
This PR fixes the issue.