### PR TITLE
Handle slashes in sysctl keys.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,10 +28,14 @@ define sysctl (
 
   # If we have a prefix, then add the dash to it
   if $prefix {
-    $sysctl_d_file = "${prefix}-${title}${suffix}"
+    $_sysctl_d_file = "${prefix}-${title}${suffix}"
   } else {
-    $sysctl_d_file = "${title}${suffix}"
+    $_sysctl_d_file = "${title}${suffix}"
   }
+
+  # Some sysctl keys contain a slash, which is not valid in a filename.
+  # Most common at those on VLANs: net.ipv4.conf.eth0/1.arp_accept = 0
+  $sysctl_d_file = regsubst($_sysctl_d_file, '/', '_', 'G')
 
   # If we have an explicit content or source, use them
   if $content or $source {

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,3 +1,4 @@
 sysctl { 'net.ipv4.ip_forward': value => '1' }
 sysctl { 'net.core.somaxconn': value => '65536' }
 sysctl { 'vm.swappiness': ensure => absent }
+sysctl { 'net.ipv4.conf.eth0/1.forwarding': value => 1 }


### PR DESCRIPTION
Some sysctl keys contain a slash in the name of the key.
This is common when VLANs are involved:
net.ipv4.conf.eth0/1.forwarding = 1

They will never conflict with another key having an underscore in the
same position, so simply replace the slash with an underscore.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>