### PR TITLE
Check the runtime value of the sysctl variables

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,12 +78,12 @@ define sysctl (
     if ! ( $content or $source ) {
         # If you supply an arbitrary value for the sysctl.d file we cannot
         # check the running configuration.  We do additional escaping for sanity
-        $qTitle = shellquote($title)
-        $qValue = shellquote($value)
-        $qKV    = shellquote("${title}=${value}")
+        $qtitle = shellquote($title)
+        $qvalue = shellquote($value)
+        $qkv    = shellquote("${title}=${value}")
         exec { "enforce-sysctl-value-${title}":
-            unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qTitle})\" = ${qValue}",
-            command => "/sbin/sysctl -w ${qKV}",
+            unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",
+            command => "/sbin/sysctl -w ${qkv}",
         }
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@ define sysctl (
         $qTitle = shellquote($title)
         $qValue = shellquote($value)
         $qKV    = shellquote("${title}=${value}")
-        exec { "check-sysctl-value-${title}":
+        exec { "enforce-sysctl-value-${title}":
             unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qTitle})\" = ${qValue}",
             command => "/sbin/sysctl -w ${qKV}",
         }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,8 +79,8 @@ define sysctl (
         # If you supply an arbitrary value for the sysctl.d file we cannot
         # check the running configuration
         exec { "check-sysctl-value-${title}":
-            unless  => "/usr/bin/test `/sbin/sysctl -n ${title}` = ${value}",
-            command => "/sbin/sysctl -w ${title}=\"${value}\"",
+            unless  => "/usr/bin/test `/sbin/sysctl -n ${title}` = '${value}'",
+            command => "/sbin/sysctl -w '${title}=${value}'",
         }
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,15 @@ define sysctl (
       onlyif      => "grep -E '^${title} *=' /etc/sysctl.conf",
     }
 
+    if ! ( $content or $source ) {
+        # If you supply an arbitrary value for the sysctl.d file we cannot
+        # check the running configuration
+        exec { "check-sysctl-value-${title}":
+            unless  => "/usr/bin/test `/sbin/sysctl -n ${title}` = ${value}",
+            command => "/sbin/sysctl -w ${title}=\"${value}\"",
+        }
+    }
+
   } else {
 
     # Absent

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,10 +77,13 @@ define sysctl (
 
     if ! ( $content or $source ) {
         # If you supply an arbitrary value for the sysctl.d file we cannot
-        # check the running configuration
+        # check the running configuration.  We do additional escaping for sanity
+        $qTitle = shellquote($title)
+        $qValue = shellquote($value)
+        $qKV    = shellquote("${title}=${value}")
         exec { "check-sysctl-value-${title}":
-            unless  => "/usr/bin/test `/sbin/sysctl -n ${title}` = '${value}'",
-            command => "/sbin/sysctl -w '${title}=${value}'",
+            unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qTitle})\" = ${qValue}",
+            command => "/sbin/sysctl -w ${qKV}",
         }
     }
 

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,3 +1,12 @@
 sysctl { 'net.ipv4.ip_forward': value => '1' }
 sysctl { 'net.core.somaxconn': value => '65536' }
 sysctl { 'vm.swappiness': ensure => absent }
+
+sysctl { 'kernel.core_pattern':
+    value   => "|/var/admin/scripts/core-gzip.sh /var/tmp/core/core.%e.%p.%h.%t.gz",
+    comment => "wrapper script so that gzip can be given an output path for the coredump",
+}
+
+sysctl { 'kernel.domainname':
+    value => "foobar.'backquote.com",
+}


### PR DESCRIPTION
If the current runtime values for the sysctl variables do not match what
we are putting in the sysctl.d/ files, then set the sysctl variable as
well.  This will correct drift that occurs for whatever reason.