### PR TITLE
Keep symlink99

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 * Update project_page and source in metadata.json file (#25).
 
+2015-06-20 - 1.0.3
+Improve handling of the symlink /etc/sysctl.d/99-sysctl.conf
+* Add parameter sysctl::params $keep_symlink99
+* Keep automatically /etc/sysctl.d/99-sysctl.conf on Debian 8 
+
 2014-12-22 - 1.0.2
 * Fix metadata.json file (#18).
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ To enable purging of settings, you can use hiera to set the `sysctl::base`
 # sysctl
 sysctl::base::purge: true
 ```
+
+If purging is enabled, check if your system uses a symlink called 
+/etc/sysctl.d/99-sysctl.conf. You explicity can keep this symlink if you set the
+`sysctl::params` `keep_symlink99` parameter to true.
+```puppet
+sysctl::params { keep_symlink99 => true }
+sysctl::base { purge => true }
+```
+
+This symlink is kept by default on RedHat 7 and Debian 8
+
+
  
 ## Hiera
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,7 @@ class sysctl::params(
   else {
     # Keep the original symlink if we purge, to avoid ping-pong with initscripts
     case "${::osfamily}-${::operatingsystemmajrelease}" {
-      'RedHat-7', 'Debian-9': {
+      'RedHat-7', 'Debian-8': {
         $symlink99 = true
       }
       default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,12 +1,18 @@
-class sysctl::params {
-
-  # Keep the original symlink if we purge, to avoid ping-pong with initscripts
-  case "${::osfamily}-${::operatingsystemmajrelease}" {
-    'RedHat-7': {
-      $symlink99 = true
-    }
-    default: {
-      $symlink99 = false
+class sysctl::params(
+	$keep_symlink99 = false,
+) {
+  if $keep_symlink99 {
+  	$symlink99 = true
+  }
+  else {
+    # Keep the original symlink if we purge, to avoid ping-pong with initscripts
+    case "${::osfamily}-${::operatingsystemmajrelease}" {
+      'RedHat-7', 'Debian-9': {
+        $symlink99 = true
+      }
+      default: {
+        $symlink99 = false
+      }
     }
   }
 
@@ -24,4 +30,3 @@ class sysctl::params {
   }
 
 }
-

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "thias-sysctl",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Matthias Saou",
   "license": "Apache-2.0",
   "summary": "Sysctl module",
@@ -19,7 +19,7 @@
     },
     {
     "operatingsystem":"Debian",
-    "operatingsystemrelease":[ "6", "7" ]
+    "operatingsystemrelease":[ "6", "7", "8" ]
     },
     {
     "operatingsystem":"Ubuntu",


### PR DESCRIPTION
Improve handling of the symlink /etc/sysctl.d/99-sysctl.conf
Add parameter sysctl::params $keep_symlink99 to force keeping of 99-sysctl.conf
Keep automatically /etc/sysctl.d/99-sysctl.conf on Debian 8 