### PR TITLE
Make purge behavior remove /etc/sysctl.conf file

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -7,6 +7,7 @@ class sysctl::base (
   $values             = undef,
   $hiera_merge_values = false,
   $symlink99          = $::sysctl::params::symlink99,
+  $sysctl_file        = $::sysctl::params::sysctl_file,
   $sysctl_dir         = $::sysctl::params::sysctl_dir,
   $sysctl_dir_path    = $::sysctl::params::sysctl_dir_path,
   $sysctl_dir_owner   = $::sysctl::params::sysctl_dir_owner,
@@ -27,6 +28,9 @@ class sysctl::base (
   if $sysctl_dir {
     if $purge {
       $recurse = true
+      file { $sysctl_file:
+        ensure => absent
+      }
     } else {
       $recurse = false
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class sysctl::params {
       $sysctl_dir = false
     }
     default: {
+      $sysctl_file = '/etc/sysctl.conf'
       $sysctl_dir = true
       $sysctl_dir_path = '/etc/sysctl.d'
       $sysctl_dir_owner = 'root'

--- a/templates/sysctl.d-file.erb
+++ b/templates/sysctl.d-file.erb
@@ -1,3 +1,4 @@
+# Managed by Puppet
 <% if @comment.is_a?(Array) -%>
 <% @comment.each do |line| -%>
 # <%= line %>


### PR DESCRIPTION
Many variables are set there additionally, so both should be purged
ideally, if such is desired.

Also add comment stating the file is managed by Puppet for the configuration
files.