### PR TITLE
Added default value to hiera_hash call

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -16,7 +16,7 @@ class sysctl::base (
 
   # Hiera support
   if $hiera_merge_values == true {
-    $values_real = hiera_hash('sysctl::base::values')
+    $values_real = hiera_hash('sysctl::base::values', {})
   } else {
     $values_real = $values
   }


### PR DESCRIPTION
This allows the module to fail gracefully if the 'sysctl::base::values' key is not defined. When it is not defined this change passes along an empty hash rather than throwing a runtime error. The create_resources function handles empty hashes just fine so this won't cause any issues.