### PR TITLE
Explicitly set $file_content and $file_source

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,8 +38,11 @@ define sysctl (
   $sysctl_d_file = regsubst($_sysctl_d_file, '/', '_', 'G')
 
   # If we have an explicit content or source, use them
-  if $content or $source {
+  if $content {
     $file_content = $content
+    $file_source = undef
+  } elsif $source {
+    $file_content = undef
     $file_source = $source
   } else {
     $file_content = template("${module_name}/sysctl.d-file.erb")


### PR DESCRIPTION
Without these changes, I get an error when using your module with the [strict_variables](https://docs.puppetlabs.com/references/latest/configuration.html#strictvariables) setting enabled.  This will be the default for Puppet 5.