### PR TITLE
Real fix for issue #37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 2016-02-05 - 1.0.6
+* Real fix enforcing for values with spaces, convert tabs to spaces (#37, @mattpascoe).
+ 
 #### 2016-02-05 - 1.0.5
 * Fix enforcing for values with spaces (#37, @mattpascoe).
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ define sysctl (
       $qvalue = shellquote("${value}")
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = \"${qvalue}\"",
+          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle}|sed 's/\t/ /g')\" = ${qvalue}",
           command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "thias-sysctl",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "Matthias Saou",
   "license": "Apache-2.0",
   "summary": "Sysctl module",


### PR DESCRIPTION
My last suggestion for quotes was incorrect, the real problem was tabs within the result of sysctl -n.  I have made those adjustments and done actual testing on my instance.  Here is a pull request to update the prior problem created in v1.0.5.