### PR TITLE
Ignore errors from sysctl

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,7 @@ define sysctl (
 
     # The immediate change + re-check on each run "just in case"
     exec { "sysctl-${title}":
-      command     => "sysctl -p /etc/sysctl.d/${sysctl_d_file}",
+      command     => "sysctl -e -p /etc/sysctl.d/${sysctl_d_file}",
       path        => [ '/usr/sbin', '/sbin', '/usr/bin', '/bin' ],
       refreshonly => true,
       require     => File["/etc/sysctl.d/${sysctl_d_file}"],


### PR DESCRIPTION
Configuration of the kernel bridge module on virtual hosts causes `sysctl` to generate misleading errors due to when exactly the bridge module is loaded. I am getting such errors during my Puppet runs:

```
Exec[sysctl-net.netfilter.nf_conntrack_tcp_timeout_established]/returns: error: "net.netfilter.nf_conntrack_tcp_timeout_established" is an unknown key
```

This PR add's the `-e` flag to ignore any such errors during execution.

More details: http://wiki.libvirt.org/page/Net.bridge-nf-call_and_sysctl.conf

Should you be okay with the change, please consider creating a new tag so we can start using the updated version. Thanks for all your work!
