### PR TITLE
Enforce exec should find sysctl, test from path

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,8 +90,9 @@ define sysctl (
       $qvalue = shellquote("${value}")
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",
-          command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
+        unless  => "test \"$(sysctl -n ${qtitle})\" = ${qvalue}",
+        command => "sysctl -w ${qtitle}=${qvalue}",
+        path    => [ '/usr/sbin', '/sbin', '/usr/bin', '/bin' ],
       }
     }
 


### PR DESCRIPTION
On Gentoo, sysctl is in `/usr/sbin`, not `/sbin`, resulting in an error like:

```
Error: Could not find command '/sbin/sysctl'
Error: /Stage[main]/Sysctl[vm.min_free_kbytes]/Exec[enforce-sysctl-value-vm.min_free_kbytes]/returns: change from notrun
```

Other `exec`s in this defined type use the path to find `sysctl`, so the enforce `exec` should as well.

This also fixes the indentation of the block to be consistent with the rest of the file.