### PR TITLE
adds unless param, so that a custom compare string can be used for exec

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@
 define sysctl (
   $ensure  = undef,
   $value   = undef,
+  $unless  = undef,
   $prefix  = undef,
   $suffix  = '.conf',
   $comment = undef,
@@ -88,9 +89,14 @@ define sysctl (
       # Convert any numerical to expected string, 0 instead of '0' would fail
       # lint:ignore:only_variable_string Convert numerical to string
       $qvalue = shellquote("${value}")
+      if $validate {
+        $rvalue = shellquote("${unless}")
+      } else {
+        $rvalue = $qvalue
+      }
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",
+          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = \"$(/bin/echo -e '${rvalue}')\"",
           command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
       }
     }
@@ -107,4 +113,3 @@ define sysctl (
   }
 
 }
-


### PR DESCRIPTION
I have an entry with mutliple values.
sysctl -n key, will return these values with a tab in between.

This commit will add a unless param, that can be used to compare the origin value with.

file based hiera)
sysctl::base::values:
  net.ipv4.ip_local_port_range:
    value: '1024 65535'
    unless: '1024\\t65535'

a space is compared underneath with 2 backslashes and a t. (\\t)
