### PR TITLE
Support Puppet v4

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,4 +1,3 @@
 fixtures:
   symlinks:
     sysctl: "#{source_dir}"
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,37 @@
-spec/fixtures
-pkg/*
+# Default .gitignore for Ruby
+*.gem
+*.rbc
+.bundle
+.config
+coverage
+InstalledFiles
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp
 
+# YARD artifacts
+.yardoc
+_yardoc
+doc/
+
+# Vim
+*.swp
+
+# Eclipse
+.project
+
+# Visual Studio Code
+.vscode/
+
+# OS X
+.DS_Store
+
+# Puppet
+coverage/
+spec/fixtures/manifests/*
+spec/fixtures/modules/*
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,90 @@
+---
+language: ruby
+
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.3.1
+
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.4.0"
+    - PUPPET_GEM_VERSION="~> 3.5.0"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+    - PUPPET_GEM_VERSION="~> 3.8.0"
+    - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+    - PUPPET_GEM_VERSION="~> 4.0.0"
+    - PUPPET_GEM_VERSION="~> 4.1.0"
+    - PUPPET_GEM_VERSION="~> 4.2.0"
+    - PUPPET_GEM_VERSION="~> 4.3.0"
+    - PUPPET_GEM_VERSION="~> 4.4.0"
+    - PUPPET_GEM_VERSION="~> 4.5.0"
+    - PUPPET_GEM_VERSION="~> 4.6.0"
+    - PUPPET_GEM_VERSION="~> 4.7.0"
+    - PUPPET_GEM_VERSION="~> 4.8.0"
+    - PUPPET_GEM_VERSION="~> 4"
+
+sudo: false
+
+script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
+
+matrix:
+  fast_finish: true
+  exclude:
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.2.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.3.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.4.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.5.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.6.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.7.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.8.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.5.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.6.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.7.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.8.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,30 @@
-source :rubygems
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-puppetversion = ENV['PUPPET_VERSION']
-gem 'puppet', puppetversion, :require => false
-gem 'puppet-lint'
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+gem 'puppetlabs_spec_helper', '>= 1.2.0'
+gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet'
-gem 'puppetlabs_spec_helper', '>= 0.4.0'
+gem 'puppet-lint', '~> 2.0'
+gem 'puppet-lint-absolute_classname-check'
+gem 'puppet-lint-alias-check'
+gem 'puppet-lint-empty_string-check'
+gem 'puppet-lint-file_ensure-check'
+gem 'puppet-lint-file_source_rights-check'
+gem 'puppet-lint-leading_zero-check'
+gem 'puppet-lint-spaceship_operator_without_tag-check'
+gem 'puppet-lint-trailing_comma-check'
+gem 'puppet-lint-undef_in_function-check'
+gem 'puppet-lint-unquoted_string-check'
+gem 'puppet-lint-variable_contains_upcase'
 
+gem 'rspec',     '~> 2.0'   if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+gem 'rake',      '~> 10.0'  if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+gem 'json',      '<= 1.8'   if RUBY_VERSION < '2.0.0'
+gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+gem 'metadata-json-lint', '0.0.11'   if RUBY_VERSION < '1.9'
+gem 'metadata-json-lint'             if RUBY_VERSION >= '1.9'

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To enable purging of settings, you can use hiera to set the `sysctl::base`
 # sysctl
 sysctl::base::purge: true
 ```
- 
+
 ## Hiera
 
 It is also possible to manage all sysctl keys using hiera, through the
@@ -90,4 +90,3 @@ sysctl { 'libvirtd':
   source => "puppet:///modules/${module_name}/libvirtd.sysctl",
 }
 ```
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,19 @@
-require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet-lint'
-PuppetLint.configuration.send("disable_80chars")
-PuppetLint.configuration.send("disable_autoloader_layout")
-PuppetLint.configuration.send("disable_quoted_booleans")
+require 'puppet-lint/tasks/puppet-lint'
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
+PuppetLint.configuration.relative = true
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
+desc 'Validate manifests, templates, and ruby files'
+task :validate do
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -27,14 +27,7 @@
     }
   ],
   "requirements": [
-    {
-    "name": "pe",
-    "version_requirement": "3.x"
-    },
-    {
-    "name": "puppet",
-    "version_requirement": ">=2.7.20 <4.1.0"
-    }
+    {"name":"puppet","version_requirement":">= 3.0.0 < 5.0.0" }
   ],
   "dependencies": []
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,18 @@
-require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |config|
+  config.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+  config.before :each do
+    # Ensure that we don't accidentally cache facts and environment between
+    # test cases.  This requires each example group to explicitly load the
+    # facts being exercised with something like
+    # Facter.collection.loader.load(:ipaddress)
+    Facter.clear
+    Facter.clear_messages
+  end
+  config.default_facts = {
+    :environment               => 'rp_env',
+    :osfamily                  => 'RedHat',
+    :operatingsystemmajrelease => '6',
+  }
+end

--- a/tests/base.pp
+++ b/tests/base.pp
@@ -1,1 +1,1 @@
-include sysctl::base
+include ::sysctl::base


### PR DESCRIPTION
Modernize module

* Drop support for Puppet v2.

* Add support for Puppet v4.

* Explicitly test against supported Ruby and Puppet matrix.

* Support Ruby versions 1.8.7, 1.9.3, 2.0.0, 2.1.0 and 2.3.1.

* Use puppet-lint v2.

* Use community puppet-lint plugins (Code already complied with the
  style).