### PR TITLE
use "path =>" for last exec as well

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,8 +90,9 @@ define sysctl (
       $qvalue = shellquote("${value}")
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",
-          command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
+          unless  => "test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",
+          command => "sysctl -w ${qtitle}=${qvalue}",
+          path    => [ '/usr/sbin', '/sbin', '/usr/bin', '/bin' ],
       }
     }
 


### PR DESCRIPTION
This seems to be enough for gentoo support, but since I unfortunately can't do more thorough testing right now, I haven't added gentoo to the supported OSs in metadata.json.