### PR TITLE
Use tab for whitespace when checking sysctl output

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,7 +87,7 @@ define sysctl (
       # Value may contain '|' and others, we need to quote to be safe
       # Convert any numerical to expected string, 0 instead of '0' would fail
       # lint:ignore:only_variable_string Convert numerical to string
-      $qvalue = shellquote("${value}")
+      $qvalue = shellquote(regsubst("${value}", '\W+', "\t", 'G'))
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
           unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",


### PR DESCRIPTION
When outputing a value the sysctl utility will print tabs for
whitespace, rather than space characters. Users, however, will commonly
use spaces rather than tabs when specifying their values.

Prior to this commit, the discrepancy between user input and sysctl
output caused idempotency problems when Puppet was enforcing sysctl
settings such as the following:

    sysctl { 'kernel.sem':
      ensure  => present,
      value   => '1000 32000 32 512',
    }

Puppet would run `sysctl -n kernel.sem` which would output with tabs:

    1000    32000   32      512

It would then compare this value to the user input, which had spaces:

    1000 32000 32 512

Finding the two values to be different, Puppet would faithfully run
sysctl to "fix" the out-of-sync setting.

    sysctl -w kernel.sem='1000 32000 32 512'

This commit fixes the problem by having Puppet compare the output of
sysctl with a tab-whitespace version of the user input, even if the user
specified spaces.

This logic (whitespace normalization) has also been used to fix the
problem in several other Puppet sysctl modules.