### PR TITLE
Add Suse 12 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,9 @@ class sysctl::params {
 
   # Keep the original symlink if we purge, to avoid ping-pong with initscripts
   case "${::osfamily}-${::operatingsystemmajrelease}" {
-    'RedHat-7','Debian-8': {
+    'RedHat-7',
+    'Debian-8',
+    'Suse-12': {
       $symlink99 = true
     }
     default: {

--- a/metadata.json
+++ b/metadata.json
@@ -24,6 +24,10 @@
     {
     "operatingsystem": "Ubuntu",
     "operatingsystemrelease": [ "12", "14" ]
+    },
+    {
+    "operatingsystem": "Suse",
+    "operatingsystemrelease": [ "12" ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
We've been using this module on Suse 12 for a while and it works fine, so I included Suse 12 in the list of supported systems.
Just recent Suse update introduced a symlink:
`/etc/sysctl.d/99-sysctl.conf -> /etc/sysctl.conf`
so I also enabled the corresponding flag.