### PR TITLE
Prevent multiple spaces in sysctl value

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ define sysctl (
       $qvalue = shellquote("${value}")
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",
+          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle} | sed 's/\\s\{1,\}/ /g')\" = ${qvalue}",
           command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
       }
     }


### PR DESCRIPTION
When setting a sysctl value that consists of multiple numbers (like `net.ipv4.ip_local_port_range`, with a value like `1024 65535`), the configured value will be 'enforced' on every puppet run, since the output of `sysctl -n` will display the output with a tab character instead of a single space.

To prevent the value from being set on every puppet run, I've added a sed command to replace multiple spaces (or tabs) with a single space when comparing the current value.