### PR TITLE
Pipe output from '/sbin/sysctl -n' through sed to remove spaces/tabs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ define sysctl (
       $qvalue = shellquote("${value}")
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle} | sed -r 's/[ \t]+/ /g')\" = ${qvalue}",
+          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle} | /usr/bin/sed -r -e 's/[ \t]+/ /g')\" = ${qvalue}",
           command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ define sysctl (
       $qvalue = shellquote("${value}")
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",
+          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle} | sed -r 's/[ \t]+/ /g')\" = ${qvalue}",
           command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
       }
     }

--- a/spec/classes/sysctl_base_spec.rb
+++ b/spec/classes/sysctl_base_spec.rb
@@ -2,6 +2,13 @@ require 'spec_helper'
 
 describe 'sysctl::base', :type => :class do
 
+  let(:facts) do
+    {
+      :osfamily => 'RedHat',
+      :operatingsystemmajrelease => '8',
+    }
+  end
+
   it { should create_class('sysctl::base') }
   it { should contain_file('/etc/sysctl.d') }
 

--- a/spec/defines/sysctl_init_spec.rb
+++ b/spec/defines/sysctl_init_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 describe 'sysctl', :type => :define do
   let(:title) { 'net.ipv4.ip_forward'}
 
+  let(:facts) do
+    {
+      :osfamily => 'RedHat',
+      :operatingsystemmajrelease => '8',
+    }
+  end
+
   context 'present' do
     let(:params) { { :value => '1' } }
 


### PR DESCRIPTION
The exec resource `"enforce-sysctl-value-${qtitle}"` for enforcing sysctl values fails for kernel parameters whose values are returned as a white space separated tuple.

Example:

`% /sbin/sysctl -n net.ipv4.tcp_wmem`
`4096	229376	4194304` 

Each value in the results is separated by a horizontal tab which, if not removed, causes the call to `/usr/bin/test` to always fail and Puppet to report that a change has been applied when none should have. 

One can verify the presence of tabs in the output by piping it through `/usr/bin/xxd`.

`% /sbin/sysctl -n net.ipv4.tcp_wmem | xxd`
`00000000: 3430 3936 0932 3239 3337 3609 3431 3934  4096.229376.4194`
`00000010: 3330 340a                                304.`

Tabs are the bytes with the value `09`.

By piping the output through sed tabs are converted to a single white space making comparison possible:

`% /sbin/sysctl -n net.ipv4.tcp_wmem | sed -r -e 's/[ \t]+/ /g' | xxd`
`00000000: 3430 3936 2032 3239 3337 3620 3431 3934  4096 229376 4194`
`00000010: 3330 340a                                304.`

Space characters are the bytes with the value `20`.

I would have included an automated unit test to verify this but I am unfamiliar with how write tests for Puppet modules. However, I did test it manually and it works on RHEL 8. 

Kernel parameters that don't contain tabs are unaffected and are enforced as normal. 
  