### PR TITLE
Hiera hash deprecation

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -13,7 +13,6 @@ class sysctl::base (
   $sysctl_dir_group   = $::sysctl::params::sysctl_dir_group,
   $sysctl_dir_mode    = $::sysctl::params::sysctl_dir_mode,
 ) inherits ::sysctl::params {
-
   # Hiera support
   if $hiera_merge_values == true {
     $values_real = hiera_hash('sysctl::base::values', {})
@@ -48,6 +47,4 @@ class sysctl::base (
       }
     }
   }
-
 }
-

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -2,32 +2,17 @@
 #
 # Common part for the sysctl definition. Not meant to be used on its own.
 #
-# @param purge
-#    Wether to purge unmanaged files. Default: false.
-# @param values
-#    Values for the sysctl function
-
-### TODO: write documentation about these params
-
-# @param hiera_merge_values
-# @param symlink99
-# @param sysctl_dir
-# @param sysctl_dir_path
-# @param sysctl_dir_owner
-# @param sysctl_dir_group
-# @param sysctl_dir_mode
-#    
 class sysctl::base (
-  Boolean $purge              = false,
-  String  $values             = undef,
-  Boolean $hiera_merge_values = false,
-  Boolean $symlink99          = $sysctl::params::symlink99,
-  Boolean $sysctl_dir         = $sysctl::params::sysctl_dir,
-  String  $sysctl_dir_path    = $sysctl::params::sysctl_dir_path,
-  String  $sysctl_dir_owner   = $sysctl::params::sysctl_dir_owner,
-  String  $sysctl_dir_group   = $sysctl::params::sysctl_dir_group,
-  String  $sysctl_dir_mode    = $sysctl::params::sysctl_dir_mode,
-) inherits sysctl::params {
+  $purge              = false,
+  $values             = undef,
+  $hiera_merge_values = false,
+  $symlink99          = $::sysctl::params::symlink99,
+  $sysctl_dir         = $::sysctl::params::sysctl_dir,
+  $sysctl_dir_path    = $::sysctl::params::sysctl_dir_path,
+  $sysctl_dir_owner   = $::sysctl::params::sysctl_dir_owner,
+  $sysctl_dir_group   = $::sysctl::params::sysctl_dir_group,
+  $sysctl_dir_mode    = $::sysctl::params::sysctl_dir_mode,
+) inherits ::sysctl::params {
   # Hiera support
   if $hiera_merge_values == true {
     $values_real = hiera_hash('sysctl::base::values', {})

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -15,7 +15,7 @@ class sysctl::base (
 ) inherits ::sysctl::params {
   # Hiera support
   if $hiera_merge_values == true {
-    $values_real = hiera_hash('sysctl::base::values', {})
+    $values_real = lookup('sysctl::base::values', {})
   } else {
     $values_real = $values
   }

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -2,17 +2,32 @@
 #
 # Common part for the sysctl definition. Not meant to be used on its own.
 #
+# @param purge
+#    Wether to purge unmanaged files. Default: false.
+# @param values
+#    Values for the sysctl function
+
+### TODO: write documentation about these params
+
+# @param hiera_merge_values
+# @param symlink99
+# @param sysctl_dir
+# @param sysctl_dir_path
+# @param sysctl_dir_owner
+# @param sysctl_dir_group
+# @param sysctl_dir_mode
+#    
 class sysctl::base (
-  $purge              = false,
-  $values             = undef,
-  $hiera_merge_values = false,
-  $symlink99          = $::sysctl::params::symlink99,
-  $sysctl_dir         = $::sysctl::params::sysctl_dir,
-  $sysctl_dir_path    = $::sysctl::params::sysctl_dir_path,
-  $sysctl_dir_owner   = $::sysctl::params::sysctl_dir_owner,
-  $sysctl_dir_group   = $::sysctl::params::sysctl_dir_group,
-  $sysctl_dir_mode    = $::sysctl::params::sysctl_dir_mode,
-) inherits ::sysctl::params {
+  Boolean $purge              = false,
+  String  $values             = undef,
+  Boolean $hiera_merge_values = false,
+  Boolean $symlink99          = $sysctl::params::symlink99,
+  Boolean $sysctl_dir         = $sysctl::params::sysctl_dir,
+  String  $sysctl_dir_path    = $sysctl::params::sysctl_dir_path,
+  String  $sysctl_dir_owner   = $sysctl::params::sysctl_dir_owner,
+  String  $sysctl_dir_group   = $sysctl::params::sysctl_dir_group,
+  String  $sysctl_dir_mode    = $sysctl::params::sysctl_dir_mode,
+) inherits sysctl::params {
   # Hiera support
   if $hiera_merge_values == true {
     $values_real = hiera_hash('sysctl::base::values', {})

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,38 +3,28 @@
 # Manage sysctl variable values.
 #
 # Parameters:
-# @param value
+#  $value:
 #    The value for the sysctl parameter. Mandatory, unless $ensure is 'absent'.
-# @param prefix
+#  $prefix:
 #    Optional prefix for the sysctl.d file to be created. Default: none.
-# @param suffix
-#    Optional suffix for the sysctl.d file to be created. Default: '.conf'.
-# @param comment
-#    Optional Array or String to put inside the sysctl.d file.
-# @param content
-#    File content of the specific sysctl_d_file.
-# @param source
-#    File source of the specific sysctl_d_file.
-# @param ensure
+#  $ensure:
 #    Whether the variable's value should be 'present' or 'absent'.
 #    Defaults to 'present'.
-# @param enforce
-#    Boolean value for the enforcement of the rule. Default: true
 #
 # Sample Usage :
 #  sysctl { 'net.ipv6.bindv6only': value => '1' }
 #
 define sysctl (
-  String                $ensure  = undef,
-  String                $value   = undef,
-  String                $prefix  = undef,
-  String                $suffix  = '.conf',
-  Variant[String,Array] $comment = undef,
-  Optional[String]      $content = undef,
-  Optional[String]      $source  = undef,
-  Boolean               $enforce = true,
+  $ensure  = undef,
+  $value   = undef,
+  $prefix  = undef,
+  $suffix  = '.conf',
+  $comment = undef,
+  $content = undef,
+  $source  = undef,
+  $enforce = true,
 ) {
-  include 'sysctl::base'
+  include '::sysctl::base'
 
   # If we have a prefix, then add the dash to it
   if $prefix {
@@ -56,7 +46,7 @@ define sysctl (
     $file_source = undef
   }
 
-  if $ensure != 'false' {
+  if $ensure != 'absent' {
     # Present
 
     # The permanent change
@@ -98,8 +88,8 @@ define sysctl (
       $qvalue = shellquote("${value}")
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-        unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",
-        command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
+          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",
+          command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
       }
     }
   } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,6 @@ define sysctl (
   $source  = undef,
   $enforce = true,
 ) {
-
   include '::sysctl::base'
 
   # If we have a prefix, then add the dash to it
@@ -48,7 +47,6 @@ define sysctl (
   }
 
   if $ensure != 'absent' {
-
     # Present
 
     # The permanent change
@@ -68,7 +66,7 @@ define sysctl (
     # The immediate change + re-check on each run "just in case"
     exec { "sysctl-${title}":
       command     => "sysctl -p /etc/sysctl.d/${sysctl_d_file}",
-      path        => [ '/usr/sbin', '/sbin', '/usr/bin', '/bin' ],
+      path        => ['/usr/sbin', '/sbin', '/usr/bin', '/bin'],
       refreshonly => true,
       require     => File["/etc/sysctl.d/${sysctl_d_file}"],
     }
@@ -76,7 +74,7 @@ define sysctl (
     # For the few original values from the main file
     exec { "update-sysctl.conf-${title}":
       command     => "sed -i -e 's#^${title} *=.*#${title} = ${value}#' /etc/sysctl.conf",
-      path        => [ '/usr/sbin', '/sbin', '/usr/bin', '/bin' ],
+      path        => ['/usr/sbin', '/sbin', '/usr/bin', '/bin'],
       refreshonly => true,
       onlyif      => "grep -E '^${title} *=' /etc/sysctl.conf",
     }
@@ -94,17 +92,12 @@ define sysctl (
           command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
       }
     }
-
   } else {
-
     # Absent
     # We cannot restore values, since defaults can not be known... reboot :-/
 
     file { "/etc/sysctl.d/${sysctl_d_file}":
       ensure => absent,
     }
-
   }
-
 }
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,28 +3,38 @@
 # Manage sysctl variable values.
 #
 # Parameters:
-#  $value:
+# @param value
 #    The value for the sysctl parameter. Mandatory, unless $ensure is 'absent'.
-#  $prefix:
+# @param prefix
 #    Optional prefix for the sysctl.d file to be created. Default: none.
-#  $ensure:
+# @param suffix
+#    Optional suffix for the sysctl.d file to be created. Default: '.conf'.
+# @param comment
+#    Optional Array or String to put inside the sysctl.d file.
+# @param content
+#    File content of the specific sysctl_d_file.
+# @param source
+#    File source of the specific sysctl_d_file.
+# @param ensure
 #    Whether the variable's value should be 'present' or 'absent'.
 #    Defaults to 'present'.
+# @param enforce
+#    Boolean value for the enforcement of the rule. Default: true
 #
 # Sample Usage :
 #  sysctl { 'net.ipv6.bindv6only': value => '1' }
 #
 define sysctl (
-  $ensure  = undef,
-  $value   = undef,
-  $prefix  = undef,
-  $suffix  = '.conf',
-  $comment = undef,
-  $content = undef,
-  $source  = undef,
-  $enforce = true,
+  String                $ensure  = undef,
+  String                $value   = undef,
+  String                $prefix  = undef,
+  String                $suffix  = '.conf',
+  Variant[String,Array] $comment = undef,
+  Optional[String]      $content = undef,
+  Optional[String]      $source  = undef,
+  Boolean               $enforce = true,
 ) {
-  include '::sysctl::base'
+  include 'sysctl::base'
 
   # If we have a prefix, then add the dash to it
   if $prefix {
@@ -46,7 +56,7 @@ define sysctl (
     $file_source = undef
   }
 
-  if $ensure != 'absent' {
+  if $ensure != 'false' {
     # Present
 
     # The permanent change
@@ -88,8 +98,8 @@ define sysctl (
       $qvalue = shellquote("${value}")
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",
-          command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
+        unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",
+        command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
       }
     }
   } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,9 +1,8 @@
 class sysctl::params {
-
   # Keep the original symlink if we purge, to avoid ping-pong with initscripts
   if ($::osfamily == 'RedHat' and
       versioncmp($::operatingsystemmajrelease, '7') >= 0) or
-     ($::osfamily == 'Debian' and
+    ($::osfamily == 'Debian' and
       versioncmp($::operatingsystemmajrelease, '8') >= 0) {
     $symlink99 = true
   } else {
@@ -22,6 +21,4 @@ class sysctl::params {
       $sysctl_dir_mode = '0755'
     }
   }
-
 }
-

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,16 +1,15 @@
-# parameters for systcl
 class sysctl::params {
   # Keep the original symlink if we purge, to avoid ping-pong with initscripts
-  if ($facts['os']['family'] == 'RedHat' and
-  versioncmp($facts['os']['release']['major'], '7') >= 0) or
-  ($facts['os']['family'] == 'Debian' and
-  versioncmp($facts['os']['release']['major'], '8') >= 0) {
+  if ($::osfamily == 'RedHat' and
+      versioncmp($::operatingsystemmajrelease, '7') >= 0) or
+    ($::osfamily == 'Debian' and
+      versioncmp($::operatingsystemmajrelease, '8') >= 0) {
     $symlink99 = true
   } else {
     $symlink99 = false
   }
 
-  case $facts['os']['family'] {
+  case $::osfamily {
     'FreeBSD': {
       $sysctl_dir = false
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,15 +1,16 @@
+# parameters for systcl
 class sysctl::params {
   # Keep the original symlink if we purge, to avoid ping-pong with initscripts
-  if ($::osfamily == 'RedHat' and
-      versioncmp($::operatingsystemmajrelease, '7') >= 0) or
-    ($::osfamily == 'Debian' and
-      versioncmp($::operatingsystemmajrelease, '8') >= 0) {
+  if ($facts['os']['family'] == 'RedHat' and
+  versioncmp($facts['os']['release']['major'], '7') >= 0) or
+  ($facts['os']['family'] == 'Debian' and
+  versioncmp($facts['os']['release']['major'], '8') >= 0) {
     $symlink99 = true
   } else {
     $symlink99 = false
   }
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'FreeBSD': {
       $sysctl_dir = false
     }


### PR DESCRIPTION
The hiera_hash function is deprecated in favor of the lookup function